### PR TITLE
Enable java-only projects for testing

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -174,7 +174,7 @@ jobs:
             architecture: "amd64"
             buildContainers: false
             modules: "./,oauth-common,oauth-client,oauth-server"
-            nexusCheck: "oauth-common"
+            nexusCheck: "kafka-oauth-common"
             javaVersion: "17"
             helmChartName: "none"
             releaseVersion: "6.6.6"


### PR DESCRIPTION
This PR adds projects that didn't had makefile during earlier implementation. Now the build process should be unified and all projects should be testable as part of ITs in this repo.