### PR TITLE
Bump multiple actions we are using to partially fix the NodeJS deprecation

### DIFF
--- a/.github/actions/build/build-binaries/action.yml
+++ b/.github/actions/build/build-binaries/action.yml
@@ -131,7 +131,7 @@ runs:
 
     - name: Upload artifact
       if: ${{ inputs.mainJavaBuild == 'true' }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: binaries-${{ inputs.artifactSuffix }}.tar
         path: binaries-${{ inputs.artifactSuffix }}.tar

--- a/.github/actions/build/build-containers/action.yml
+++ b/.github/actions/build/build-containers/action.yml
@@ -67,7 +67,7 @@ runs:
       run: "tar -cvpf containers-${{ inputs.artifactSuffix }}-${{ inputs.architecture }}.tar ${{ inputs.imagesDir }}"
 
     - name: Upload containers artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: containers-${{ inputs.artifactSuffix }}-${{ inputs.architecture }}.tar
         path: containers-${{ inputs.artifactSuffix }}-${{ inputs.architecture }}.tar

--- a/.github/actions/build/push-containers/action.yml
+++ b/.github/actions/build/push-containers/action.yml
@@ -144,7 +144,7 @@ runs:
       # The keyless signing doesn't work on pull_requests events so this part will be tested only during push events
       # It shouldn't affect the usage in Strimzi projects as images are always pushed and signed during push or workflow_dispatch events
       if: ${{ github.event_name != 'pull_request' }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: SBOMs-${{ inputs.artifactSuffix }}-${{ inputs.containerTag }}.tar.gz
         path: sbom.tar.gz

--- a/.github/actions/build/release-artifacts/action.yml
+++ b/.github/actions/build/release-artifacts/action.yml
@@ -38,7 +38,7 @@ runs:
           -exec tar -rvf release-${{ inputs.artifactSuffix }}-${{ inputs.releaseVersion }}.tar {} \;
 
     - name: Upload release artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: release-${{ inputs.artifactSuffix }}-${{ inputs.releaseVersion }}.tar
         path: release-${{ inputs.artifactSuffix }}-${{ inputs.releaseVersion }}.tar

--- a/.github/actions/dependencies/install-docker/action.yml
+++ b/.github/actions/dependencies/install-docker/action.yml
@@ -9,12 +9,12 @@ runs:
       run: "docker --version"
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
       with:
         platforms: all
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       with:
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         driver: docker


### PR DESCRIPTION
This PR fixes issue with the NodeJS deprecation (#22) as there are still two actions we are waiting for update of NodeJS and release of the actions themself:

- https://github.com/dorny/test-reporter/issues/680
- https://github.com/stCarolas/setup-maven/issues/41