### PR TITLE
Skip second build for CO repo and properly set helm and maven packages for KAO and OAuth

### DIFF
--- a/.github/actions/build/build-binaries/action.yml
+++ b/.github/actions/build/build-binaries/action.yml
@@ -98,6 +98,8 @@ runs:
     # Common build steps
     #############################################################
     - name: Run tests and verification
+      # Tests for operators repo are in separated workflow and this is just a redundant step
+      if: ${{ inputs.clusterOperatorBuild == 'true' }}
       shell: bash
       run: |
           make java_install

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -48,7 +48,7 @@ jobs:
             buildContainers: true
             modules: "./"
             nexusCheck: "kafka-bridge"
-            javaVersion: "17"
+            javaVersion: "21"
             helmChartName: "none"
             releaseVersion: "6.6.6"
             imagesDir: "kafka-bridge-amd64.tar.gz"

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -63,7 +63,7 @@ jobs:
             modules: "./,api"
             nexusCheck: "kafka-access-operator"
             javaVersion: "21"
-            helmChartName: "none"
+            helmChartName: "strimzi-access-operator-helm-3-chart"
             releaseVersion: "6.6.6"
             imagesDir: "access-operator-container-amd64.tar.gz"
             clusterOperatorBuild: false
@@ -172,7 +172,7 @@ jobs:
             artifactSuffix: "kafka-oauth"
             architecture: "amd64"
             buildContainers: false
-            modules: "./,oauth-common,oauth-client,oauth-server"
+            modules: "!examples/producer','!examples/consumer"
             nexusCheck: "kafka-oauth-common"
             javaVersion: "17"
             helmChartName: "none"


### PR DESCRIPTION
This PR skips second build for operators repo as it is not needed for tests, because they are executed in separated worklow. It also fixes helm name in tests for KAO and maven packages for oauth.