### PR TITLE
Bump setup-maven action after latest release

### DIFF
--- a/.github/actions/dependencies/setup-java/action.yml
+++ b/.github/actions/dependencies/setup-java/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: ${{ inputs.mavenVersion }}
 


### PR DESCRIPTION
This PR bumps the `setup-maven` action to get rid of the "NodeJS deprecation" (which was bumped to 24 in latest release 5.1).