### PR TITLE
Search for release artifacts with case insensitive query

### DIFF
--- a/.github/actions/build/release-artifacts/action.yml
+++ b/.github/actions/build/release-artifacts/action.yml
@@ -32,9 +32,9 @@ runs:
       run: |
         # Find all release artifacts and create tarball
         # This will include .tar.gz, .zip, .tgz (Helm charts), and any other release files
-        find . -type f \( -name "*${{ inputs.releaseVersion }}*.tar.gz" -o \
-                          -name "*${{ inputs.releaseVersion }}*.zip" -o \
-                          -name "*${{ inputs.releaseVersion }}*.tgz" \) \
+        find . -type f \( -iname "*${{ inputs.releaseVersion }}*.tar.gz" -o \
+                          -iname "*${{ inputs.releaseVersion }}*.zip" -o \
+                          -iname "*${{ inputs.releaseVersion }}*.tgz" \) \
           -exec tar -rvf release-${{ inputs.artifactSuffix }}-${{ inputs.releaseVersion }}.tar {} \;
 
     - name: Upload release artifacts

--- a/.github/workflows/reusable-test-integrations.yml
+++ b/.github/workflows/reusable-test-integrations.yml
@@ -66,7 +66,7 @@ jobs:
   test-build-binaries:
     name: Build Binaries
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout ${{ inputs.repo }}
         uses: actions/checkout@v6

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -50,7 +50,7 @@ jobs:
             nexusCheck: "kafka-bridge"
             javaVersion: "21"
             helmChartName: "none"
-            releaseVersion: "6.6.6"
+            releaseVersion: "6.6.6-rc1"
             imagesDir: "kafka-bridge-amd64.tar.gz"
             clusterOperatorBuild: false
 


### PR DESCRIPTION
With first try of Bridge release we found out that changing version for release files are filtered out due to version change from `rc1` to `RC1`. This PR should solve it.