### PR TITLE
Use proper condition for skipping second operator build

### DIFF
--- a/.github/actions/build/build-binaries/action.yml
+++ b/.github/actions/build/build-binaries/action.yml
@@ -99,7 +99,7 @@ runs:
     #############################################################
     - name: Run tests and verification
       # Tests for operators repo are in separated workflow and this is just a redundant step
-      if: ${{ inputs.clusterOperatorBuild == 'true' }}
+      if: ${{ inputs.clusterOperatorBuild != 'true' }}
       shell: bash
       run: |
           make java_install

--- a/.github/workflows/reusable-test-integrations.yml
+++ b/.github/workflows/reusable-test-integrations.yml
@@ -112,7 +112,8 @@ jobs:
           artifactSuffix: ${{ inputs.artifactSuffix }}
           clusterOperatorBuild: ${{ inputs.clusterOperatorBuild }}
         env:
-          MVN_ARGS: "-DskipITs"
+          # Skip just ITs and rerun unit tests in case of flakes
+          MVN_ARGS: "-DskipITs -Dsurefire.rerunFailingTestsCount=5"
 
       - name: Verify binaries artifact was created
         run: |

--- a/.github/workflows/reusable-test-integrations.yml
+++ b/.github/workflows/reusable-test-integrations.yml
@@ -200,6 +200,15 @@ jobs:
       - name: Install yq
         uses: ./.github/actions/dependencies/install-yq
 
+      # The central-publishing-maven-plugin creates a bundle zip for release versions
+      # and uploads via the Central Portal API, which local Nexus doesn't support.
+      # Setting a SNAPSHOT version forces direct artifact deployment instead.
+      # This is required for projects where we use release branches, and it is used only for testing purposes.
+      - name: Set SNAPSHOT version for testing
+        shell: bash
+        run: |
+          mvn versions:set -DnewVersion=${{ inputs.releaseVersion }}-SNAPSHOT -DgenerateBackupPoms=false
+
       - name: Deploy to local Maven repository using deploy-java action
         uses: ./.github/actions/build/deploy-java
         with:

--- a/.github/workflows/reusable-test-integrations.yml
+++ b/.github/workflows/reusable-test-integrations.yml
@@ -51,6 +51,11 @@ on:
         description: "Flag whether it is Strimzi Operator build or not (should be set only in Strimzi Kafka Operator repo)"
         required: false
         type: boolean
+      checkTests:
+        description: "Flag whether unit tests should be run and verified during build (set to false for repos without tests)"
+        required: false
+        type: boolean
+        default: true
       githubActionsRef:
         description: "Ref of strimzi/github-actions to use (tag, branch, or SHA). Leave empty for local calls within github-actions repo."
         required: false
@@ -107,8 +112,7 @@ jobs:
           artifactSuffix: ${{ inputs.artifactSuffix }}
           clusterOperatorBuild: ${{ inputs.clusterOperatorBuild }}
         env:
-          # Skip integration tests but let unit tests run to verify the test step works
-          MVN_ARGS: "-B -DskipITs"
+          MVN_ARGS: "-DskipITs"
 
       - name: Verify binaries artifact was created
         run: |
@@ -122,7 +126,7 @@ jobs:
           echo "✓ Binaries artifact created successfully"
 
       - name: Verify test results exist
-        if: ${{ inputs.clusterOperatorBuild != true }}
+        if: ${{ inputs.checkTests == true }}
         shell: bash
         run: |
           REPORT_COUNT=$(find . -path "*/surefire-reports/TEST-*.xml" -type f | wc -l)

--- a/.github/workflows/reusable-test-integrations.yml
+++ b/.github/workflows/reusable-test-integrations.yml
@@ -107,8 +107,8 @@ jobs:
           artifactSuffix: ${{ inputs.artifactSuffix }}
           clusterOperatorBuild: ${{ inputs.clusterOperatorBuild }}
         env:
-          # Always skipTests during testing of the actions to save time
-          MVN_ARGS: "-B -DskipTests"
+          # Skip integration tests but let unit tests run to verify the test step works
+          MVN_ARGS: "-B -DskipITs"
 
       - name: Verify binaries artifact was created
         run: |
@@ -120,6 +120,17 @@ jobs:
           echo "Binaries artifact contents:"
           tar -tf binaries-${{ inputs.artifactSuffix }}.tar
           echo "✓ Binaries artifact created successfully"
+
+      - name: Verify test results exist
+        if: ${{ inputs.clusterOperatorBuild != true }}
+        shell: bash
+        run: |
+          REPORT_COUNT=$(find . -path "*/surefire-reports/TEST-*.xml" -type f | wc -l)
+          if [ "$REPORT_COUNT" -eq 0 ]; then
+            echo "No surefire test reports found - unit tests may not have run"
+            exit 1
+          fi
+          echo "✓ Found $REPORT_COUNT surefire test report(s)"
 
   test-deploy-java:
     name: Deploy to Maven

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -43,7 +43,7 @@ jobs:
 
           # Kafka Bridge - Full pipeline with containers
           - repo: "strimzi/strimzi-kafka-bridge"
-            ref: "main"
+            ref: "release-1.0.x"
             artifactSuffix: "kafka-bridge"
             architecture: "amd64"
             buildContainers: true

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -39,6 +39,7 @@ jobs:
             releaseVersion: "6.6.6"
             imagesDir: "./docker-images/container-archives"
             clusterOperatorBuild: true
+            checkTests: false
 
           # Kafka Bridge - Full pipeline with containers
           - repo: "strimzi/strimzi-kafka-bridge"
@@ -53,6 +54,7 @@ jobs:
             releaseVersion: "6.6.6-rc1"
             imagesDir: "kafka-bridge-amd64.tar.gz"
             clusterOperatorBuild: false
+            checkTests: true
 
           # Access Operator - Full pipeline with containers
           - repo: "strimzi/kafka-access-operator"
@@ -67,6 +69,7 @@ jobs:
             releaseVersion: "6.6.6"
             imagesDir: "access-operator-container-amd64.tar.gz"
             clusterOperatorBuild: false
+            checkTests: true
 
           # MQTT Bridge - Full pipeline with containers
           - repo: "strimzi/strimzi-mqtt-bridge"
@@ -81,6 +84,7 @@ jobs:
             releaseVersion: "6.6.6"
             imagesDir: "mqtt-bridge-amd64.tar.gz"
             clusterOperatorBuild: false
+            checkTests: true
 
           # Drain Cleaner - Full pipeline with containers and Helm
           - repo: "strimzi/drain-cleaner"
@@ -95,8 +99,9 @@ jobs:
             releaseVersion: "6.6.6"
             imagesDir: "drain-cleaner-container-amd64.tar.gz"
             clusterOperatorBuild: false
+            checkTests: true
 
-          # Client Examples - Containers only (no Maven deploy)
+          # Client Examples - Containers only (no Maven deploy, no tests)
           - repo: "strimzi/client-examples"
             ref: "main"
             artifactSuffix: "client-examples"
@@ -109,6 +114,7 @@ jobs:
             releaseVersion: "none"
             imagesDir: "*-amd64.tar.gz"
             clusterOperatorBuild: false
+            checkTests: false
 
           # Test Clients - Containers only (no Maven deploy)
           - repo: "strimzi/test-clients"
@@ -123,6 +129,7 @@ jobs:
             releaseVersion: "6.6.6"
             imagesDir: "./docker-images/container-archives"
             clusterOperatorBuild: false
+            checkTests: true
 
           # Metrics Reporter - Java only (no containers)
           - repo: "strimzi/metrics-reporter"
@@ -137,6 +144,7 @@ jobs:
             releaseVersion: "6.6.6"
             imagesDir: "none"
             clusterOperatorBuild: false
+            checkTests: true
 
           # Kafka Quotas Plugin - Java only (no containers)
           - repo: "strimzi/kafka-quotas-plugin"
@@ -151,6 +159,7 @@ jobs:
             releaseVersion: "6.6.6"
             imagesDir: "none"
             clusterOperatorBuild: false
+            checkTests: true
 
           # Kafka Kubernetes Config Provider - Java only (no containers)
           - repo: "strimzi/kafka-kubernetes-config-provider"
@@ -165,6 +174,7 @@ jobs:
             releaseVersion: "6.6.6"
             imagesDir: "none"
             clusterOperatorBuild: false
+            checkTests: true
 
           # Kafka OAuth - Java only (no containers)
           - repo: "strimzi/strimzi-kafka-oauth"
@@ -179,6 +189,22 @@ jobs:
             releaseVersion: "6.6.6"
             imagesDir: "none"
             clusterOperatorBuild: false
+            checkTests: true
+
+          # Test Container - Java only (no containers)
+          - repo: "strimzi/test-container"
+            ref: "main"
+            artifactSuffix: "strimzi-test-container"
+            architecture: "amd64"
+            buildContainers: false
+            modules: "./"
+            nexusCheck: "strimzi-test-container"
+            javaVersion: "17"
+            helmChartName: "none"
+            releaseVersion: "6.6.6"
+            imagesDir: "none"
+            clusterOperatorBuild: false
+            checkTests: true
     
     uses: ./.github/workflows/reusable-test-integrations.yml
     with:
@@ -194,4 +220,5 @@ jobs:
       releaseVersion: ${{ matrix.project.releaseVersion }}
       imagesDir: ${{ matrix.project.imagesDir }}
       clusterOperatorBuild: ${{ matrix.project.clusterOperatorBuild }}
+      checkTests: ${{ matrix.project.checkTests }}
     secrets: inherit

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -28,7 +28,7 @@ jobs:
         project:
           # Strimzi Operator - Full pipeline with containers and Helm
           - repo: "strimzi/strimzi-kafka-operator"
-            ref: "main"
+            ref: "release-0.51.x"
             artifactSuffix: "operators"
             architecture: "amd64"
             buildContainers: true


### PR DESCRIPTION
Due to wrong condition I accidentally skip the tests execution during the build phase. This PR changes it to skip the second build properly only for Strimzi operator where the tests are executed in separated job.