### PR TITLE
Save maven cache only on pushes into default branch

### DIFF
--- a/.github/actions/build/build-binaries/action.yml
+++ b/.github/actions/build/build-binaries/action.yml
@@ -105,7 +105,8 @@ runs:
           make java_install
 
     - name: Save Maven cache
-      if: ${{ inputs.mainJavaBuild == 'true' }}
+      # Save maven cache only after pushes into default branch
+      if: ${{ inputs.mainJavaBuild == 'true' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
       uses: actions/cache/save@v5
       with:
         path: ~/.m2/repository


### PR DESCRIPTION
This PR changes when we save maven cache. Currently we save it for every build and every branch which is not optimal. It seems that GitHub's key to save cache is not just cache key, but also a branch so we end-up with same caches multiple times uploaded. It should be fixed by this PR.