### PR TITLE
Add release related yaml files into release tar ball

### DIFF
--- a/.github/actions/build/release-artifacts/action.yml
+++ b/.github/actions/build/release-artifacts/action.yml
@@ -30,11 +30,10 @@ runs:
     - name: Create release tarball
       shell: bash
       run: |
-        # Find all release artifacts and create tarball
-        # This will include .tar.gz, .zip, .tgz (Helm charts), and any other release files
         find . -type f \( -iname "*${{ inputs.releaseVersion }}*.tar.gz" -o \
                           -iname "*${{ inputs.releaseVersion }}*.zip" -o \
-                          -iname "*${{ inputs.releaseVersion }}*.tgz" \) \
+                          -iname "*${{ inputs.releaseVersion }}*.tgz" -o \
+                          -iname "*${{ inputs.releaseVersion }}*.yaml" \) \
           -exec tar -rvf release-${{ inputs.artifactSuffix }}-${{ inputs.releaseVersion }}.tar {} \;
 
     - name: Upload release artifacts

--- a/.github/workflows/reusable-test-integrations.yml
+++ b/.github/workflows/reusable-test-integrations.yml
@@ -408,6 +408,23 @@ jobs:
           tar -tf "$TARBALL"
           echo "✓ Release artifacts created successfully"
 
+      # This check is currently only for Operators repo as yamls were missing in release tar ball
+      - name: Verify YAML release artifacts in tarball
+        if: ${{ inputs.clusterOperatorBuild == true }}
+        run: |
+          TARBALL="release-${{ inputs.artifactSuffix }}-${{ inputs.releaseVersion }}.tar"
+
+          YAML_COUNT=$(tar -tf "$TARBALL" | grep -c '\.yaml$' || true)
+          if [ "$YAML_COUNT" -eq 0 ]; then
+            echo "Release tarball contents:"
+            tar -tf "$TARBALL"
+            echo "No YAML files found in release tarball for operator build"
+            exit 1
+          fi
+
+          echo "Found $YAML_COUNT YAML file(s) in release tarball:"
+          tar -tf "$TARBALL" | grep '\.yaml$'
+
   test-publish-helm:
     name: Publish Helm Charts
     if: ${{ inputs.helmChartName != 'none' }}


### PR DESCRIPTION
This PR adds release related yamls files (like `strimzi-crds-1.0.0.yaml`) into release tar ball. Without the change the yaml files weren't added into tar which resulted into incomplete tar ball.