### PR TITLE
Add possibility to run 'check released files' step not only for the Cluster Operator

### DIFF
--- a/.github/actions/build/build-binaries/action.yml
+++ b/.github/actions/build/build-binaries/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Enable Strimzi Operator specific build steps (Helm charts install, CRDs install, dashboards install, docs checks, uncommitted changes check)"
     required: false
     default: "false"
+  checkReleasedFiles:
+    description: "Enable step for checking released files - using the `make release_files_check`"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -86,7 +90,7 @@ runs:
       run: "make shellcheck"
 
     - name: Check released files
-      if: ${{ inputs.clusterOperatorBuild == 'true' }}
+      if: ${{ inputs.clusterOperatorBuild == 'true' || inputs.checkReleasedFiles == 'true' }}
       shell: bash
       run: "make release_files_check"
 


### PR DESCRIPTION
This PR adds new variable `checkReleasedFiles` that can be used to enable the 'check released files' step -> in order to run the `make release_files_check`. We should run this check even for Access Operator, however, right now we can just enable it using the `clusterOperatorBuild`, which would enable everything else as well - which is not desired right now.