### PR TITLE
Make load-containers reusable for all sub-projects

### DIFF
--- a/.github/actions/build/load-containers/action.yml
+++ b/.github/actions/build/load-containers/action.yml
@@ -1,5 +1,5 @@
-name: "Load Strimzi images"
-description: "Load Strimzi images from Build workflow"
+name: "Load images into registry"
+description: "Load images from Build workflow into registry for e2e tests"
 
 inputs:
   architecture:
@@ -21,20 +21,23 @@ inputs:
     description: "Container image tag - used for external registry"
     required: false
     default: "latest"
+  artifactSuffix:
+    description: "Suffix of archive with images"
+    required: true
 
 runs:
   using: "composite"
   steps:
-    - name: "Untar the ${{ inputs.architecture }} containers"
+    - name: "Untar ${{ inputs.architecture }} containers"
       shell: bash
-      run: tar -xvf containers-${{ inputs.architecture }}.tar
+      run: tar -xvf containers-${{ inputs.artifactSuffix }}-${{ inputs.architecture }}.tar
 
-    - name: "Delete the original archive with the ${{ inputs.architecture }} containers"
+    - name: "Delete the original archive with ${{ inputs.architecture }} containers"
       shell: bash
-      run: rm containers-${{ inputs.architecture }}.tar
+      run: rm containers-${{ inputs.artifactSuffix }}-${{ inputs.architecture }}.tar
 
     # This is for loading images into minikube registry
-    - name: Load & push Strimzi images into minikube registry
+    - name: Load & push images into minikube registry
       shell: bash
       if: ${{ contains(inputs.registry, 'minikube') }}
       run: |
@@ -47,7 +50,7 @@ runs:
         DOCKER_TAG: ${{ inputs.containerTag }}
 
     # This is for loading images into kind registry
-    - name: Load & push Strimzi images into kind registry
+    - name: Load & push images into kind registry
       shell: bash
       if: ${{ contains(inputs.registry, 'kind') }}
       run: |
@@ -59,7 +62,7 @@ runs:
         DOCKER_TAG: ${{ inputs.containerTag }}
 
     # This is for loading images into external registry
-    - name: Load & push Strimzi images external registry
+    - name: Load & push images into external registry
       shell: bash
       if: ${{ contains(inputs.registry, 'external') }}
       run: |


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

Make `load-containers` actions reusable also by KAO and Drain-cleaner. The action can now be used within operators repo as well.

Closes https://github.com/strimzi/github-actions/issues/25

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
