### PR TITLE
Add --all-projects to snyk maven scans

### DIFF
--- a/.github/actions/security/snyk-maven-scan/action.yml
+++ b/.github/actions/security/snyk-maven-scan/action.yml
@@ -25,6 +25,7 @@ runs:
       continue-on-error: true
       run: |
         snyk test \
+          --all-projects \
           --sarif-file-output=snyk-maven-${{ inputs.projectPrefix }}.sarif \
           --json-file-output=snyk-results.json
 
@@ -63,4 +64,4 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
-        snyk monitor --target-reference="${GITHUB_REF_NAME}"
+        snyk monitor --all-projects --target-reference="${GITHUB_REF_NAME}"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Maven scans should be run with `--all-projects` to scan all subprojects and not just root pom.

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
