### PR TITLE
Add exclude options to maven scan

### DIFF
--- a/.github/actions/security/snyk-container-scan/action.yml
+++ b/.github/actions/security/snyk-container-scan/action.yml
@@ -12,9 +12,6 @@ inputs:
     description: "Whether to also run 'snyk container monitor'"
     required: false
     default: "false"
-  projectPrefix:
-    description: "Project prefix for Snyk dashboard (e.g., 'strimzi')"
-    required: true
   snykMonitorTargetReference:
     description: "Value for --target-reference in 'snyk container monitor' (e.g. release version). Defaults to the image tag."
     required: false

--- a/.github/actions/security/snyk-maven-scan/action.yml
+++ b/.github/actions/security/snyk-maven-scan/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Whether to upload SARIF results to GitHub Code Scanning"
     required: false
     default: "true"
+  exclude:
+    description: "Comma-separated list of directories to exclude from scanning (e.g., 'mockkube,test')"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -24,22 +28,30 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
+        EXCLUDE_FLAG=""
+        if [ -n "${{ inputs.exclude }}" ]; then
+          EXCLUDE_FLAG="--exclude=${{ inputs.exclude }}"
+        fi
         snyk test \
           --all-projects \
+          $EXCLUDE_FLAG \
           --sarif-file-output=snyk-maven-${{ inputs.projectPrefix }}.sarif \
           --json-file-output=snyk-results.json
 
     # This is used to set severity score to 0.0 for those results that has empty value for it.
     # Empty value is not supported by GitHub Code Scanning page
+    # It also set tool.driver.name to distinguish between different tools within UI
     - name: Sanitize SARIF security-severity values
       shell: bash
       run: |
         SARIF_FILE="snyk-maven-${{ inputs.projectPrefix }}.sarif"
         if [ -f "$SARIF_FILE" ]; then
-          jq '(.runs[].tool.driver.rules[]?.properties."security-severity") |=
-            if . == null or . == "undefined" or (tostring | test("^[0-9]") | not) then "0.0"
-            else .
-            end' "$SARIF_FILE" > "${SARIF_FILE}.tmp" && mv "${SARIF_FILE}.tmp" "$SARIF_FILE"
+          jq '
+            (.runs[].tool.driver.name) = "Snyk Maven" |
+            (.runs[].tool.driver.rules[]?.properties."security-severity") |=
+              if . == null or . == "undefined" or (tostring | test("^[0-9]") | not) then "0.0"
+              else .
+              end' "$SARIF_FILE" > "${SARIF_FILE}.tmp" && mv "${SARIF_FILE}.tmp" "$SARIF_FILE"
         fi
 
     - name: Upload SARIF to GitHub Code Scanning
@@ -64,4 +76,8 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
-        snyk monitor --all-projects --target-reference="${GITHUB_REF_NAME}"
+        EXCLUDE_FLAG=""
+        if [ -n "${{ inputs.exclude }}" ]; then
+          EXCLUDE_FLAG="--exclude=${{ inputs.exclude }}"
+        fi
+        snyk monitor --all-projects $EXCLUDE_FLAG --target-reference="${GITHUB_REF_NAME}"

--- a/.github/actions/security/snyk-maven-scan/action.yml
+++ b/.github/actions/security/snyk-maven-scan/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: "Whether to also run 'snyk monitor'"
     required: false
     default: "false"
-  projectPrefix:
-    description: "Project prefix for Snyk dashboard and SARIF naming (e.g., 'strimzi')"
+  scanName:
+    description: "Name used for SARIF file naming, upload category, and tool display name (e.g., 'strimzi')"
     required: true
   uploadToCodeScanning:
     description: "Whether to upload SARIF results to GitHub Code Scanning"
@@ -35,7 +35,7 @@ runs:
         snyk test \
           --all-projects \
           $EXCLUDE_FLAG \
-          --sarif-file-output=snyk-maven-${{ inputs.projectPrefix }}.sarif \
+          --sarif-file-output=snyk-maven-${{ inputs.scanName }}.sarif \
           --json-file-output=snyk-results.json
 
     # This is used to set severity score to 0.0 for those results that has empty value for it.
@@ -44,10 +44,10 @@ runs:
     - name: Sanitize SARIF security-severity values
       shell: bash
       run: |
-        SARIF_FILE="snyk-maven-${{ inputs.projectPrefix }}.sarif"
+        SARIF_FILE="snyk-maven-${{ inputs.scanName }}.sarif"
         if [ -f "$SARIF_FILE" ]; then
-          jq '
-            (.runs[].tool.driver.name) = "Snyk Maven" |
+          jq --arg name "Snyk Maven (${{ inputs.scanName }})" '
+            (.runs[].tool.driver.name) = $name |
             (.runs[].tool.driver.rules[]?.properties."security-severity") |=
               if . == null or . == "undefined" or (tostring | test("^[0-9]") | not) then "0.0"
               else .
@@ -58,16 +58,16 @@ runs:
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       if: ${{ always() && inputs.uploadToCodeScanning == 'true' }}
       with:
-        sarif_file: snyk-maven-${{ inputs.projectPrefix }}.sarif
-        category: snyk-maven-${{ inputs.projectPrefix }}
+        sarif_file: snyk-maven-${{ inputs.scanName }}.sarif
+        category: snyk-maven-${{ inputs.scanName }}
         wait-for-processing: true
 
     - name: Upload SARIF as workflow artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
-        name: snyk-maven-${{ inputs.projectPrefix }}.sarif
-        path: snyk-maven-${{ inputs.projectPrefix }}.sarif
+        name: snyk-maven-${{ inputs.scanName }}.sarif
+        path: snyk-maven-${{ inputs.scanName }}.sarif
         retention-days: 30
 
     # Monitor command is used for upload snapshot of the scan to Snyk App where Snyk will do daily scans and can generate reports

--- a/.github/workflows/test-snyk.yml
+++ b/.github/workflows/test-snyk.yml
@@ -207,7 +207,6 @@ jobs:
           snykMonitor: "false"
           snykMonitorTargetReference: "latest"
           uploadToCodeScanning: "false"
-          projectPrefix: test-operators
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -259,7 +258,6 @@ jobs:
           snykMonitorTargetReference: "latest"
           # Keep false to avoid uploading results to GitHub Code Scanning page
           uploadToCodeScanning: "false"
-          scanName: test-drain-cleaner
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 

--- a/.github/workflows/test-snyk.yml
+++ b/.github/workflows/test-snyk.yml
@@ -62,7 +62,7 @@ jobs:
           snykMonitor: "false"
           # Keep false to avoid uploading results to GitHub Code Scanning page
           uploadToCodeScanning: "false"
-          projectPrefix: test-drain-cleaner
+          scanName: test-drain-cleaner
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -259,7 +259,7 @@ jobs:
           snykMonitorTargetReference: "latest"
           # Keep false to avoid uploading results to GitHub Code Scanning page
           uploadToCodeScanning: "false"
-          projectPrefix: test-drain-cleaner
+          scanName: test-drain-cleaner
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add `exclude` option to allow us exclude for example testing modules from the scanning. The reason for that is to reduce modules count that is uploaded to GitHub Security page.

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
