### PR TITLE
Use slightly different cmd to get node IP in kind script

### DIFF
--- a/.github/actions/dependencies/setup-kind/action.yml
+++ b/.github/actions/dependencies/setup-kind/action.yml
@@ -84,10 +84,16 @@ runs:
     - name: Set DOCKER_REGISTRY
       shell: bash
       run: |
-        echo "DOCKER_REGISTRY=$(hostname --ip-address | grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' | awk '$1 != "127.0.0.1" { print $1 }' | head -1):5001" >> $GITHUB_ENV
+        echo "DOCKER_REGISTRY=$(hostname --all-ip-addresses | awk '{ print $1 }'):5001" >> $GITHUB_ENV
 
     # This is used for building connect image used withing STs for runs where already existing images are used (releases)
     - name: Set CONNECT_BUILD_REGISTRY
       shell: bash
       run: |
-        echo "CONNECT_BUILD_REGISTRY=$(hostname --ip-address | grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' | awk '$1 != "127.0.0.1" { print $1 }' | head -1):5001" >> $GITHUB_ENV
+        echo "CONNECT_BUILD_REGISTRY=$(hostname --all-ip-addresses | awk '{ print $1 }'):5001" >> $GITHUB_ENV
+
+    - name: Print registry values
+      shell: bash
+      run: |
+        echo "DOCKER_REGISTRY=${DOCKER_REGISTRY}"
+        echo "CONNECT_BUILD_REGISTRY=${CONNECT_BUILD_REGISTRY}"

--- a/.github/actions/dependencies/setup-kind/setup-kind.sh
+++ b/.github/actions/dependencies/setup-kind/setup-kind.sh
@@ -376,7 +376,7 @@ network_name="kind"
 configure_network "${network_name}"
 
 if [[ "$IP_FAMILY" = "ipv4" || "$IP_FAMILY" = "dual" ]]; then
-    hostname=$(hostname --ip-address | grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' | awk '$1 != "127.0.0.1" { print $1 }' | head -1)
+    hostname=$(hostname --all-ip-addresses | awk '{ print $1 }')
 
     # update insecure registries
     updateContainerRuntimeConfiguration "${hostname}:${reg_port}"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

After recent changes on CNCF runners our script for setup kind doesn't return IP address of the node properly which leads to wrong value in DOCKER_REGISTRY for tests. The PR resolves it. New command was tested on CNCF runners and returns proper values.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
