### PR TITLE
Properly set target-reference when input is set

### DIFF
--- a/.github/actions/security/snyk-container-scan/action.yml
+++ b/.github/actions/security/snyk-container-scan/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: "false"
   snykMonitorTargetReference:
-    description: "Value for --target-reference in 'snyk container monitor' (e.g. release version). Defaults to the image tag."
+    description: "Version prefix for --target-reference in 'snyk container monitor' (e.g. release version). Replaces only the version prefix of the image tag, preserving any suffix (e.g. kafka version, architecture). Defaults to the full image tag."
     required: false
     default: ""
   uploadToCodeScanning:
@@ -100,7 +100,13 @@ runs:
           MONITOR_PROJECT="${LOADED_IMAGE%%:*}"
           MONITOR_REVISION="${LOADED_IMAGE##*:}"
           if [ -n "$TARGET_REFERENCE" ]; then
-            MONITOR_REVISION="$TARGET_REFERENCE"
+            TAG_PREFIX="${MONITOR_REVISION%%-*}"
+            if [ "$TAG_PREFIX" != "$MONITOR_REVISION" ]; then
+              TAG_SUFFIX="${MONITOR_REVISION#*-}"
+              MONITOR_REVISION="${TARGET_REFERENCE}-${TAG_SUFFIX}"
+            else
+              MONITOR_REVISION="$TARGET_REFERENCE"
+            fi
           fi
           snyk container monitor "$LOADED_IMAGE" \
             --project-name="$MONITOR_PROJECT" \


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We fully replace target-reference currently which si fine for main builds, but for releases we will lost Kafkas within Snyk UI as all of the scans will be reported without Kafka version. This PR resolves it.

### Checklist


- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
