### PR TITLE
Run all make targets if they are defined

### DIFF
--- a/.github/actions/build/build-binaries/action.yml
+++ b/.github/actions/build/build-binaries/action.yml
@@ -9,12 +9,12 @@ inputs:
   artifactSuffix:
     description: "Suffix/prefix for the uploaded artifact"
     required: true
-  clusterOperatorBuild:
-    description: "Enable Strimzi Operator specific build steps (Helm charts install, CRDs install, dashboards install, docs checks, uncommitted changes check)"
+  skipTests:
+    description: "Skip the test execution step and test result publishing (use when tests run in a separate workflow)"
     required: false
     default: "false"
-  checkReleasedFiles:
-    description: "Enable step for checking released files - using the `make release_files_check`"
+  clusterOperatorBuild:
+    description: "[Deprecated - use skipTests instead] When set to 'true', skips test execution. Makefile target steps are now auto-detected."
     required: false
     default: "false"
 
@@ -38,61 +38,45 @@ runs:
       env:
         MVN_ARGS: '-B -DskipTests'
 
+    #############################################################
+    # Optional build targets - each step runs only if the
+    # corresponding Makefile target exists in the project
+    #############################################################
     - name: Run SpotBugs
       shell: bash
-      run: |
-        if make -n spotbugs &>/dev/null; then
-          echo "Target exists"
-          make spotbugs
-        else
-          # TODO - Should be everywhere
-          echo "Target 'spotbugs' not found, skipping..."
-        fi
+      run: "${{ github.action_path }}/make.sh spotbugs"
 
-    #############################################################
-    # The following steps gated by clusterOperatorBuild check
-    # are used only by Strimzi Kafka Operator repository.
-    # The other projects shouldn't use them.
-    #############################################################
     - name: Setup dashboards for Helm Chart
-      if: ${{ inputs.clusterOperatorBuild == 'true' }}
       shell: bash
-      run: "make dashboard_install"
+      run: "${{ github.action_path }}/make.sh dashboard_install"
 
     - name: Generate YAMLs from Helm Chart
-      if: ${{ inputs.clusterOperatorBuild == 'true' }}
       shell: bash
-      run: "make helm_install"
+      run: "${{ github.action_path }}/make.sh helm_install"
 
     - name: Distribute CRDs
-      if: ${{ inputs.clusterOperatorBuild == 'true' }}
       shell: bash
-      run: "make crd_install"
+      run: "${{ github.action_path }}/make.sh crd_install"
 
     - name: Run Helm Chart unit tests
-      if: ${{ inputs.clusterOperatorBuild == 'true' }}
       shell: bash
-      run: "make helm_unittest"
+      run: "${{ github.action_path }}/make.sh helm_unittest"
 
     - name: Generate docs version files
-      if: ${{ inputs.clusterOperatorBuild == 'true' }}
       shell: bash
-      run: "make docu_versions"
+      run: "${{ github.action_path }}/make.sh docu_versions"
 
     - name: Check docs
-      if: ${{ inputs.clusterOperatorBuild == 'true' }}
       shell: bash
-      run: "make docu_check"
+      run: "${{ github.action_path }}/make.sh docu_check"
 
     - name: Run Shellcheck
-      if: ${{ inputs.clusterOperatorBuild == 'true' }}
       shell: bash
-      run: "make shellcheck"
+      run: "${{ github.action_path }}/make.sh shellcheck"
 
     - name: Check released files
-      if: ${{ inputs.clusterOperatorBuild == 'true' || inputs.checkReleasedFiles == 'true' }}
       shell: bash
-      run: "make release_files_check"
+      run: "${{ github.action_path }}/make.sh release_files_check"
 
     - name: Check for uncommitted files
       shell: bash
@@ -102,8 +86,7 @@ runs:
     # Common build steps
     #############################################################
     - name: Run tests and verification
-      # Tests for operators repo are in separated workflow and this is just a redundant step
-      if: ${{ inputs.clusterOperatorBuild != 'true' }}
+      if: ${{ inputs.skipTests != 'true' && inputs.clusterOperatorBuild != 'true' }}
       shell: bash
       run: |
           make java_install
@@ -146,7 +129,7 @@ runs:
 
     - name: Publish test results
       uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-      if: always() && inputs.clusterOperatorBuild != 'true'
+      if: always() && inputs.skipTests != 'true' && inputs.clusterOperatorBuild != 'true'
       with:
         name: 'Unit & Integration tests'
         path: '**/TEST-*.xml'

--- a/.github/actions/build/build-binaries/make.sh
+++ b/.github/actions/build/build-binaries/make.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+TARGET="${1:?Usage: make.sh <target-name>}"
+
+if make -n "${TARGET}" &>/dev/null; then
+  echo "Running 'make ${TARGET}'..."
+  make "${TARGET}"
+else
+  echo "Target '${TARGET}' not found in Makefile, skipping..."
+fi

--- a/.github/actions/dependencies/install-yq/action.yml
+++ b/.github/actions/dependencies/install-yq/action.yml
@@ -9,7 +9,7 @@ inputs:
   version:
     description: "Version"
     required: false
-    default: "v4.6.3"
+    default: "v4.53.3"
 
 runs:
   using: "composite"

--- a/.github/workflows/reusable-test-integrations.yml
+++ b/.github/workflows/reusable-test-integrations.yml
@@ -48,9 +48,14 @@ on:
         required: true
         type: string
       clusterOperatorBuild:
-        description: "Flag whether it is Strimzi Operator build or not (should be set only in Strimzi Kafka Operator repo)"
+        description: "[Deprecated - use skipTests instead] Flag whether it is Strimzi Operator build or not (should be set only in Strimzi Kafka Operator repo)"
         required: false
         type: boolean
+      skipTests:
+        description: "Skip test execution in build-binaries (use when tests run in a separate workflow)"
+        required: false
+        type: boolean
+        default: false
       checkTests:
         description: "Flag whether unit tests should be run and verified during build (set to false for repos without tests)"
         required: false
@@ -110,6 +115,7 @@ jobs:
         with:
           mainJavaBuild: "true"
           artifactSuffix: ${{ inputs.artifactSuffix }}
+          skipTests: ${{ inputs.skipTests }}
           clusterOperatorBuild: ${{ inputs.clusterOperatorBuild }}
         env:
           # Skip just ITs and rerun unit tests in case of flakes

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -32,7 +32,7 @@ jobs:
             artifactSuffix: "operators"
             architecture: "amd64"
             buildContainers: true
-            modules: "./,crd-annotations,crd-generator,test,api,v1-api-conversion"
+            modules: "./,crd-annotations,crd-generator,test,api"
             nexusCheck: "strimzi"
             javaVersion: "21"
             helmChartName: "strimzi-kafka-operator-helm-3-chart"

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -28,7 +28,7 @@ jobs:
         project:
           # Strimzi Operator - Full pipeline with containers and Helm
           - repo: "strimzi/strimzi-kafka-operator"
-            ref: "release-1.0.x"
+            ref: "release-1.1.x"
             artifactSuffix: "operators"
             architecture: "amd64"
             buildContainers: true
@@ -39,6 +39,7 @@ jobs:
             releaseVersion: "6.6.6"
             imagesLocation: "./docker-images/container-archives"
             clusterOperatorBuild: true
+            skipTests: true
             checkTests: false
 
           # Kafka Bridge - Full pipeline with containers
@@ -53,7 +54,7 @@ jobs:
             helmChartName: "none"
             releaseVersion: "6.6.6-rc1"
             imagesLocation: "kafka-bridge-amd64.tar.gz"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
 
           # Access Operator - Full pipeline with containers
@@ -68,7 +69,7 @@ jobs:
             helmChartName: "strimzi-access-operator-helm-3-chart"
             releaseVersion: "6.6.6"
             imagesLocation: "access-operator-container-amd64.tar.gz"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
 
           # MQTT Bridge - Full pipeline with containers
@@ -83,7 +84,7 @@ jobs:
             helmChartName: "none"
             releaseVersion: "6.6.6"
             imagesLocation: "mqtt-bridge-amd64.tar.gz"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
 
           # Drain Cleaner - Full pipeline with containers and Helm
@@ -98,7 +99,7 @@ jobs:
             helmChartName: "strimzi-drain-cleaner-helm-3-chart"
             releaseVersion: "6.6.6"
             imagesLocation: "drain-cleaner-container-amd64.tar.gz"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
 
           # Client Examples - Containers only (no Maven deploy, no tests)
@@ -113,7 +114,7 @@ jobs:
             helmChartName: "none"
             releaseVersion: "none"
             imagesLocation: "*-amd64.tar.gz"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: false
 
           # Test Clients - Containers only (no Maven deploy)
@@ -128,7 +129,7 @@ jobs:
             helmChartName: "none"
             releaseVersion: "6.6.6"
             imagesLocation: "./docker-images/container-archives"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
 
           # Metrics Reporter - Java only (no containers)
@@ -143,7 +144,7 @@ jobs:
             helmChartName: "none"
             releaseVersion: "6.6.6"
             imagesLocation: "none"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
 
           # Kafka Quotas Plugin - Java only (no containers)
@@ -158,7 +159,7 @@ jobs:
             helmChartName: "none"
             releaseVersion: "6.6.6"
             imagesLocation: "none"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
 
           # Kafka Kubernetes Config Provider - Java only (no containers)
@@ -173,7 +174,7 @@ jobs:
             helmChartName: "none"
             releaseVersion: "6.6.6"
             imagesLocation: "none"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
 
           # Kafka OAuth - Java only (no containers)
@@ -188,7 +189,7 @@ jobs:
             helmChartName: "none"
             releaseVersion: "6.6.6"
             imagesLocation: "none"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
 
           # Test Container - Java only (no containers)
@@ -203,7 +204,7 @@ jobs:
             helmChartName: "none"
             releaseVersion: "6.6.6"
             imagesLocation: "none"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
 
           # Test Connectors - Java only (no containers)
@@ -218,7 +219,7 @@ jobs:
             helmChartName: "none"
             releaseVersion: "6.6.6"
             imagesLocation: "none"
-            clusterOperatorBuild: false
+            skipTests: false
             checkTests: true
     
     uses: ./.github/workflows/reusable-test-integrations.yml
@@ -235,5 +236,6 @@ jobs:
       releaseVersion: ${{ matrix.project.releaseVersion }}
       imagesLocation: ${{ matrix.project.imagesLocation }}
       clusterOperatorBuild: ${{ matrix.project.clusterOperatorBuild }}
+      skipTests: ${{ matrix.project.skipTests || false }}
       checkTests: ${{ matrix.project.checkTests }}
     secrets: inherit

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -235,7 +235,7 @@ jobs:
       helmChartName: ${{ matrix.project.helmChartName }}
       releaseVersion: ${{ matrix.project.releaseVersion }}
       imagesLocation: ${{ matrix.project.imagesLocation }}
-      clusterOperatorBuild: ${{ matrix.project.clusterOperatorBuild }}
-      skipTests: ${{ matrix.project.skipTests || false }}
+      clusterOperatorBuild: ${{ matrix.project.clusterOperatorBuild || false }}
+      skipTests: ${{ matrix.project.skipTests }}
       checkTests: ${{ matrix.project.checkTests }}
     secrets: inherit

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -89,7 +89,8 @@ jobs:
 
           # Drain Cleaner - Full pipeline with containers and Helm
           - repo: "strimzi/drain-cleaner"
-            ref: "release-1.6.x"
+            # Use 1.7.x once it will be prepared
+            ref: "main"
             artifactSuffix: "drain-cleaner"
             architecture: "amd64"
             buildContainers: true


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Nowadays the build action runs most of the make targets only for operators repo based on `clusterOperatorBuild` parameter. This is not much suitable as other repos requires same targets to be run and are not clearly main operators repo. This PR changes the mechanism to run the make target if it's specified by makefile.

I also bumped yq to default version 4.53.3 because without it drain-cleaner command for helm_install was failing due to unknown line comment parameter. It won't affect any other projects until we will update to v2.1

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
