### PR TITLE
Bump several actions and change dependabot config

### DIFF
--- a/.github/actions/build/build-binaries/action.yml
+++ b/.github/actions/build/build-binaries/action.yml
@@ -25,7 +25,7 @@ runs:
     # Common build steps
     #############################################################
     - name: Restore Maven cache
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2/repository
         key: maven-${{ hashFiles('**/pom.xml') }}
@@ -94,7 +94,7 @@ runs:
     - name: Save Maven cache
       # Save maven cache only after pushes into default branch
       if: ${{ inputs.mainJavaBuild == 'true' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2/repository
         key: maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/actions/build/deploy-java/action.yml
+++ b/.github/actions/build/deploy-java/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Restore Maven cache
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2/repository
         key: maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/actions/build/release-artifacts/action.yml
+++ b/.github/actions/build/release-artifacts/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Restore Maven cache
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2/repository
         key: maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/actions/dependencies/setup-java/action.yml
+++ b/.github/actions/dependencies/setup-java/action.yml
@@ -23,7 +23,7 @@ runs:
       with:
         maven-version: ${{ inputs.mavenVersion }}
 
-    - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
         distribution: ${{ inputs.javaDistro }}
         java-version: ${{ inputs.javaVersion }}

--- a/.github/actions/dependencies/setup-kind/action.yml
+++ b/.github/actions/dependencies/setup-kind/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Cache registry Docker image
       id: cache-registry
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: /tmp/registry-image-${{ inputs.architecture }}.tar
         key: registry-image
@@ -52,7 +52,7 @@ runs:
 
     - name: Cache cloud-provider-kind container image
       id: cache-cloud-provider-kind
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: /tmp/cloud-provider-kind-image-${{ inputs.architecture }}.tar
         key: cloud-provider-kind

--- a/.github/actions/dependencies/setup-minikube/action.yml
+++ b/.github/actions/dependencies/setup-minikube/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
     - name: Cache registry Docker image
       id: cache-registry
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: /tmp/registry-image.tar
         key: registry-image

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       - "/.github/actions/utils/*"
     schedule:
       interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: actions
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -58,6 +58,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/test-snyk.yml
+++ b/.github/workflows/test-snyk.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/dependencies/install-yq
 
       - name: Restore Maven cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

Bumps for `cache`, `setup-java` and `codeql` actions. I also changed config for dependabot to open one PR for all dependency changes per week instead creating one per action.

### Checklist

- [x] Make sure all tests pass
