### PR TITLE
Add fossa-scan actions

### DIFF
--- a/.github/actions/security/fossa-container-scan/action.yml
+++ b/.github/actions/security/fossa-container-scan/action.yml
@@ -1,0 +1,114 @@
+name: "FOSSA Container Scan"
+description: "Scan a single container image with FOSSA for license compliance and vulnerability analysis"
+
+inputs:
+  imageFile:
+    description: "Path to container image file for docker load"
+    required: true
+  image:
+    description: "Image name for artifact naming and categorization"
+    required: true
+  scanName:
+    description: "Name used as FOSSA project name. Defaults to the image name if not set."
+    required: false
+    default: ""
+  fossaTest:
+    description: "Whether to also run 'fossa container test' for policy compliance checking"
+    required: false
+    default: "false"
+  fossaTeam:
+    description: "Team name that is used for uploading results."
+    required: false
+    default: "Strimzi"
+  branch:
+    description: "Branch name to associate with this scan in FOSSA (e.g., branch name or image tag)"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install FOSSA CLI
+      shell: bash
+      run: |
+        curl -H 'Cache-Control: no-cache' \
+          https://raw.githubusercontent.com/fossas/fossa-cli/f9cd35ff5d917672d5433c46603de4ed92c53a0d/install-latest.sh | bash # v3.17.12
+
+    - name: Load container image
+      shell: bash
+      env:
+        IMAGE_FILE: ${{ inputs.imageFile }}
+        IMAGE_NAME: ${{ inputs.image }}
+      run: |
+        if [ ! -f "$IMAGE_FILE" ]; then
+          echo "::error::Image file not found: $IMAGE_FILE"
+          exit 1
+        fi
+
+        LOAD_OUTPUT=$(docker load < "$IMAGE_FILE")
+        echo "$LOAD_OUTPUT"
+        LOADED_IMAGE=$(echo "$LOAD_OUTPUT" | grep "Loaded image" | sed 's/Loaded image: //')
+
+        if [ -z "$LOADED_IMAGE" ]; then
+          echo "::error::Could not determine loaded image tag for $IMAGE_NAME"
+          exit 1
+        fi
+
+        echo "LOADED_IMAGE=$LOADED_IMAGE" >> "$GITHUB_ENV"
+
+    - name: Run FOSSA Container Analyze
+      shell: bash
+      continue-on-error: true
+      run: |
+        ANALYZE_LOG=$(mktemp)
+        set +e
+        SCAN_NAME="${{ inputs.scanName }}"
+        if [ -z "$SCAN_NAME" ]; then
+          SCAN_NAME="${{ inputs.image }}"
+        fi
+        fossa container analyze \
+          --project "$SCAN_NAME" \
+          --team "${{ inputs.fossaTeam }}" \
+          --branch "${{ inputs.branch }}" \
+          "$LOADED_IMAGE" > "$ANALYZE_LOG" 2>&1
+        set -e
+        cat "$ANALYZE_LOG"
+        FOSSA_URL=$(grep -o 'https://app.fossa.com[^ ]*' "$ANALYZE_LOG" | head -1 || true)
+        echo "FOSSA_URL=$FOSSA_URL" >> "$GITHUB_ENV"
+        rm -f "$ANALYZE_LOG"
+
+    - name: Run FOSSA Test and Write Summary
+      if: always()
+      shell: bash
+      run: |
+        set +e
+        SCAN_NAME="${{ inputs.scanName }}"
+        if [ -z "$SCAN_NAME" ]; then
+          SCAN_NAME="${{ inputs.image }}"
+        fi
+        TEST_OUTPUT=$(fossa container test --project "$SCAN_NAME" "$LOADED_IMAGE" 2>&1)
+        TEST_EXIT_CODE=$?
+        set -e
+        echo "$TEST_OUTPUT"
+
+        if [ "${{ inputs.fossaTest }}" == "true" ]; then
+          if [ "$TEST_EXIT_CODE" -eq 0 ]; then
+            TEST_RESULT="✅ passed"
+          else
+            TEST_RESULT="❌ failed"
+          fi
+        else
+          TEST_RESULT="⏭️ skipped"
+        fi
+
+        echo "## FOSSA Scan Summary" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Type | Image | Report | Test |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|------|-------|--------|------|" >> "$GITHUB_STEP_SUMMARY"
+        if [ -n "$FOSSA_URL" ]; then
+          echo "| Container | ${{ inputs.image }} | [View in FOSSA]($FOSSA_URL) | $TEST_RESULT |" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "| Container | ${{ inputs.image }} | ❌ upload failed | $TEST_RESULT |" >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::FOSSA container analyze failed — no report URL found in output"
+          exit 1
+        fi

--- a/.github/actions/security/fossa-maven-scan/.fossa.yml
+++ b/.github/actions/security/fossa-maven-scan/.fossa.yml
@@ -1,0 +1,6 @@
+version: 3
+
+maven:
+  scope-exclude:
+    - test
+    - provided

--- a/.github/actions/security/fossa-maven-scan/action.yml
+++ b/.github/actions/security/fossa-maven-scan/action.yml
@@ -1,0 +1,100 @@
+name: "FOSSA Maven Scan"
+description: "Run FOSSA scan on Maven dependencies with license compliance and vulnerability analysis"
+
+inputs:
+  fossaTest:
+    description: "Whether to also run 'fossa test' for policy compliance checking"
+    required: false
+    default: "false"
+  scanName:
+    description: "Name used for artifact naming (e.g., 'strimzi')"
+    required: true
+  exclude:
+    description: "Comma-separated list of directories to exclude from scanning (e.g., 'mockkube,test')"
+    required: false
+    default: ""
+  fossaTeam:
+    description: "Team name that is used for uploading results."
+    required: false
+    default: "Strimzi"
+  branch:
+    description: "Branch name to associate with this scan in FOSSA (e.g., branch name or image tag)"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install FOSSA CLI
+      shell: bash
+      run: |
+        curl -H 'Cache-Control: no-cache' \
+          https://raw.githubusercontent.com/fossas/fossa-cli/f9cd35ff5d917672d5433c46603de4ed92c53a0d/install-latest.sh | bash # v3.17.12
+
+    - name: Configure FOSSA
+      shell: bash
+      run: |
+        if [ -f .fossa.yml ]; then
+          echo "::warning::Existing .fossa.yml found in workspace — using project configuration instead of action defaults"
+        else
+          cp "${{ github.action_path }}/.fossa.yml" .fossa.yml
+        fi
+
+        if [ -n "${{ inputs.exclude }}" ]; then
+          echo "" >> .fossa.yml
+          echo "paths:" >> .fossa.yml
+          echo "  exclude:" >> .fossa.yml
+          IFS=',' read -ra DIRS <<< "${{ inputs.exclude }}"
+          for dir in "${DIRS[@]}"; do
+            dir=$(echo "$dir" | xargs)
+            echo "    - $dir/" >> .fossa.yml
+          done
+        fi
+
+    - name: Run FOSSA Analyze
+      shell: bash
+      continue-on-error: true
+      run: |
+        ANALYZE_LOG=$(mktemp)
+        set +e
+        fossa analyze \
+          --project "${{ inputs.scanName }}" \
+          --team "${{ inputs.fossaTeam }}" \
+          --branch "${{ inputs.branch }}" > "$ANALYZE_LOG" 2>&1
+        set -e
+        cat "$ANALYZE_LOG"
+        FOSSA_URL=$(grep -o 'https://app.fossa.com[^ ]*' "$ANALYZE_LOG" | head -1 || true)
+        echo "FOSSA_URL=$FOSSA_URL" >> "$GITHUB_ENV"
+        rm -f "$ANALYZE_LOG"
+
+    - name: Run FOSSA Test and Write Summary
+      if: always()
+      shell: bash
+      run: |
+        set +e
+        TEST_OUTPUT=$(fossa test --project "${{ inputs.scanName }}" 2>&1)
+        TEST_EXIT_CODE=$?
+        set -e
+        echo "$TEST_OUTPUT"
+
+        if [ "${{ inputs.fossaTest }}" == "true" ]; then
+          if [ "$TEST_EXIT_CODE" -eq 0 ]; then
+            TEST_RESULT="✅ passed"
+          else
+            TEST_RESULT="❌ failed"
+          fi
+        else
+          TEST_RESULT="⏭️ skipped"
+        fi
+
+        echo "## FOSSA Scan Summary" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Type | Project | Report | Test |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|------|---------|--------|------|" >> "$GITHUB_STEP_SUMMARY"
+        if [ -n "$FOSSA_URL" ]; then
+          echo "| Maven | ${{ inputs.scanName }} | [View in FOSSA]($FOSSA_URL) | $TEST_RESULT |" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "| Maven | ${{ inputs.scanName }} | ❌ upload failed | $TEST_RESULT |" >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::FOSSA analyze failed — no report URL found in output"
+          exit 1
+        fi

--- a/.github/workflows/test-fossa.yml
+++ b/.github/workflows/test-fossa.yml
@@ -1,4 +1,4 @@
-name: Snyk Scan Tests
+name: FOSSA Scan Tests
 
 on:
   # Due to security constraints we cannot run the workflow on PRs due to missing secrets on PRs from forks
@@ -10,15 +10,14 @@ on:
 permissions:
   contents: read
   actions: read
-  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test-snyk-maven-scan:
-    name: Test Snyk Maven Scan
+  test-fossa-maven-scan:
+    name: Test FOSSA Maven Scan
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -55,37 +54,15 @@ jobs:
         shell: bash
         run: mvn -B -DskipTests -Dmaven.javadoc.skip=true clean install
 
-      - name: Run Snyk Maven scan
-        uses: ./.github/actions/security/snyk-maven-scan
+      - name: Run FOSSA Maven scan
+        uses: ./.github/actions/security/fossa-maven-scan
         with:
-          # Keep false to avoid uploading testing results to Snyk App
-          snykMonitor: "false"
-          # Keep false to avoid uploading results to GitHub Code Scanning page
-          uploadToCodeScanning: "false"
-          scanName: test-drain-cleaner
+          # Keep false to avoid running policy tests during testing
+          fossaTest: "true"
+          scanName: test-maven-drain-cleaner
+          branch: "1.6.1"
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
-      - name: Download SARIF artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: snyk-maven-test-drain-cleaner.sarif
-          path: sarif-output
-
-      - name: Verify SARIF artifact
-        shell: bash
-        run: |
-          SARIF_FILE="sarif-output/snyk-maven-test-drain-cleaner.sarif"
-          if [ ! -f "$SARIF_FILE" ]; then
-            echo "SARIF file not found: $SARIF_FILE"
-            exit 1
-          fi
-          if [ ! -s "$SARIF_FILE" ]; then
-            echo "SARIF file is empty: $SARIF_FILE"
-            exit 1
-          fi
-          jq empty "$SARIF_FILE"
-          echo "SARIF file is valid JSON with $(jq '.runs | length' "$SARIF_FILE") run(s)"
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   # Test workflow loads image artifacts from test-integrations workflow.
   # To avoid additional image build, the scan check will wait until integration workflow store the artifacts
@@ -101,8 +78,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_SHA: ${{ github.sha }}
-          ARTIFACT_NAME: "containers-operators-amd64.tar"
-          MAX_WAIT_MINUTES: "80"
+          ARTIFACT_NAME: "containers-drain-cleaner-amd64.tar"
+          MAX_WAIT_MINUTES: "20"
         with:
           script: |
             const {owner, repo} = context.repo;
@@ -169,64 +146,8 @@ jobs:
               await new Promise(resolve => setTimeout(resolve, 30000));
             }
 
-  test-snyk-container-scan-operators:
-    name: Test Snyk Container Scan (${{ matrix.image }})
-    needs: wait-for-container-artifact
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        image:
-          # Kafka images are not here to avoid need to change Kafka versions on multiple places when we bump operators repo versions for testing
-          - buildah-latest-amd64
-          - kaniko-executor-latest-amd64
-          - maven-builder-latest-amd64
-          - operator-latest-amd64
-    steps:
-      - name: Checkout github-actions
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install Docker
-        uses: ./.github/actions/dependencies/install-docker
-
-      - name: Download container archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: containers-operators-amd64.tar
-          run-id: ${{ needs.wait-for-container-artifact.outputs.run-id }}
-          github-token: ${{ github.token }}
-
-      - name: Untar container archive
-        run: tar -xvf containers-operators-amd64.tar
-
-      - name: Run Snyk container scan
-        uses: ./.github/actions/security/snyk-container-scan
-        with:
-          imageFile: docker-images/container-archives/${{ matrix.image }}.tar.gz
-          image: ${{ matrix.image }}
-          snykMonitor: "false"
-          snykMonitorTargetReference: "latest"
-          uploadToCodeScanning: "false"
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
-      - name: Verify SARIF artifact
-        shell: bash
-        run: |
-          SARIF_FILE="snyk-container-${{ matrix.image }}.sarif"
-          if [ ! -f "$SARIF_FILE" ]; then
-            echo "SARIF file not found: $SARIF_FILE"
-            exit 1
-          fi
-          if [ ! -s "$SARIF_FILE" ]; then
-            echo "SARIF file is empty: $SARIF_FILE"
-            exit 1
-          fi
-          jq empty "$SARIF_FILE"
-          echo "SARIF file is valid JSON with $(jq '.runs | length' "$SARIF_FILE") run(s)"
-
-  test-snyk-container-scan-drain-cleaner:
-    name: Test Snyk Container Scan (drain-cleaner)
+  test-fossa-container-scan-drain-cleaner:
+    name: Test FOSSA Container Scan (drain-cleaner)
     needs: wait-for-container-artifact
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -248,30 +169,13 @@ jobs:
       - name: Untar container archive
         run: tar -xvf containers-drain-cleaner-amd64.tar
 
-      - name: Run Snyk container scan
-        uses: ./.github/actions/security/snyk-container-scan
+      - name: Run FOSSA container scan
+        uses: ./.github/actions/security/fossa-container-scan
         with:
           imageFile: drain-cleaner-container-amd64.tar.gz
           image: drain-cleaner-amd64
-          # Keep false to avoid uploading testing results to Snyk App
-          snykMonitor: "false"
-          snykMonitorTargetReference: "latest"
-          # Keep false to avoid uploading results to GitHub Code Scanning page
-          uploadToCodeScanning: "false"
+          scanName: test-container-drain-cleaner-amd64
+          fossaTest: "true"
+          branch: "1.6.1"
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
-      - name: Verify SARIF artifact
-        shell: bash
-        run: |
-          SARIF_FILE="snyk-container-drain-cleaner-amd64.sarif"
-          if [ ! -f "$SARIF_FILE" ]; then
-            echo "SARIF file not found: $SARIF_FILE"
-            exit 1
-          fi
-          if [ ! -s "$SARIF_FILE" ]; then
-            echo "SARIF file is empty: $SARIF_FILE"
-            exit 1
-          fi
-          jq empty "$SARIF_FILE"
-          echo "SARIF file is valid JSON with $(jq '.runs | length' "$SARIF_FILE") run(s)"
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -89,8 +89,7 @@ jobs:
 
           # Drain Cleaner - Full pipeline with containers and Helm
           - repo: "strimzi/drain-cleaner"
-            # Use 1.7.x once it will be prepared
-            ref: "main"
+            ref: "1.6.1"
             artifactSuffix: "drain-cleaner"
             architecture: "amd64"
             buildContainers: true

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Actions for building, testing, and releasing Strimzi components.
 > The `build-binaries` action supports an `clusterOperatorBuild` input (default `false`) that enables Strimzi Kafka Operator specific build steps — Helm chart generation, CRD distribution, dashboard setup, documentation checks, and uncommitted changes verification.
 > Other repositories should leave this disabled.
 
+### Security Actions
+
+Actions for security scanning of dependencies and container images.
+
+| Action                              | Description                                                          | Key Inputs                                              |
+|-------------------------------------|----------------------------------------------------------------------|---------------------------------------------------------|
+| `security/snyk-maven-scan`         | Run Snyk scan on Maven dependencies with SARIF upload                | `scanName` (required), `snykMonitor`, `exclude`         |
+| `security/snyk-container-scan`     | Scan a container image with Snyk, upload results to Code Scanning    | `imageFile` (required), `image` (required), `snykMonitor` |
+| `security/fossa-maven-scan`        | Run FOSSA scan on Maven dependencies for license and vulnerability analysis | `scanName` (required), `fossaTest`, `exclude`    |
+| `security/fossa-container-scan`    | Scan a container image with FOSSA for license and vulnerability analysis | `imageFile` (required), `image` (required), `fossaTest` |
+
 ### Utils Actions
 
 Actions used as utils mostly in operators repository.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds licence/security scanning actions via FOSSA clients. This is mainly an option for us to pick between FOSSA and Snyk if we decide to migrate from one to another. An example of test run ca be found here https://github.com/Frawless/github-actions/actions/runs/29052465289 .

### Checklist

- [x] Update documentation
- [x] Write tests
- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
