### PR TITLE
Block first party licence scans to speendup the scans

### DIFF
--- a/.github/actions/security/fossa-maven-scan/action.yml
+++ b/.github/actions/security/fossa-maven-scan/action.yml
@@ -58,6 +58,7 @@ runs:
         ANALYZE_LOG=$(mktemp)
         set +e
         fossa analyze \
+          --experimental-block-first-party-scans \
           --project "${{ inputs.scanName }}" \
           --team "${{ inputs.fossaTeam }}" \
           --branch "${{ inputs.branch }}" > "$ANALYZE_LOG" 2>&1


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

It seems that CNCF has by default enabled first party licence scanning. It means taht fossa cli goes through all files within the repo and do pattern matching for licences. This makes the scans quite long. I think we can let the app/integration do it if needed and skip in our actions.

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
