### PR TITLE
Ensure that jobs within attestation matrix will not fail-fast

### DIFF
--- a/.github/workflows/reusable-attest.yml
+++ b/.github/workflows/reusable-attest.yml
@@ -151,6 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         image: ${{ fromJSON(inputs.containerImages) }}
     steps:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In case there is an rekor speed degradation, some attestation jobs may fail. THis config ensures that one failed job will not stop the others.

### Checklist

- [x] Make sure all tests pass
