### PR TITLE
Use main branch for operators repo to avoid build issues

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -29,7 +29,8 @@ jobs:
         project:
           # Strimzi Operator - Full pipeline with containers and Helm
           - repo: "strimzi/strimzi-kafka-operator"
-            ref: "release-1.1.x"
+            # There was problem with prometheus download urls which was fixed in main and will be part of 1.2.x
+            ref: "main"
             artifactSuffix: "operators"
             architecture: "amd64"
             buildContainers: true


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The build of operators is failing due to wrong Prometheus URLs. It was fixed by https://github.com/strimzi/strimzi-kafka-operator/pull/13013 but it is not in `release-1.1.x` branch. We will switch to main until 1.2.0 will be branched.

In case we will do another 2.x release, we should cherry-pick this one.

### Checklist

- [x] Make sure all tests pass
